### PR TITLE
Fix `waitfor` callback leak

### DIFF
--- a/src/wait-for.js
+++ b/src/wait-for.js
@@ -37,13 +37,13 @@ function waitFor(
     },
   },
 ) {
-  if (typeof callback !== 'function') {
+  if (typeof originalCallback !== 'function') {
     throw new TypeError('Received `callback` arg must be a function')
   }
 
   // callback will be replaced by a noop function as soon as it finishes
   // to prevent callback leaking calls
-  let callback = originalCallback;
+  let callback = originalCallback
 
   return new Promise(async (resolve, reject) => {
     let lastError, intervalId, observer
@@ -111,7 +111,7 @@ function waitFor(
 
     function onDone(error, result) {
       finished = true
-      callback = () => {};
+      callback = () => {}
       clearTimeout(overallTimeoutTimer)
 
       if (!usingJestFakeTimers) {

--- a/src/wait-for.js
+++ b/src/wait-for.js
@@ -16,7 +16,7 @@ function copyStackTrace(target, source) {
 }
 
 function waitFor(
-  callback,
+  originalCallback,
   {
     container = getDocument(),
     timeout = getConfig().asyncUtilTimeout,
@@ -40,6 +40,10 @@ function waitFor(
   if (typeof callback !== 'function') {
     throw new TypeError('Received `callback` arg must be a function')
   }
+
+  // callback will be replaced by a noop function as soon as it finishes
+  // to prevent callback leaking calls
+  let callback = originalCallback;
 
   return new Promise(async (resolve, reject) => {
     let lastError, intervalId, observer
@@ -107,6 +111,7 @@ function waitFor(
 
     function onDone(error, result) {
       finished = true
+      callback = () => {};
       clearTimeout(overallTimeoutTimer)
 
       if (!usingJestFakeTimers) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Prevent `waitFor` callback from being invoked even after it resolved.
<!-- Why are these changes necessary? -->

**Why**:

More context can be found [in this issue](https://github.com/testing-library/dom-testing-library/issues/1270), but with that context in mind, it's preventing test side-effects:

`afterEach` should be enough to "clean" the previous test from any side-effect.  However, because of the callback leak issue, `window.variable` will remain to be `123` even after being set back to `1` for a short period of time. 

```js
afterEach(() => {
 window.variable = 1;
})
it('my test', () => {
  return waitFor(() => {
    window.variable = 123;
    throw new Error('I want it to timeout');
  })
})
```


<!-- How were these changes implemented? -->

**How**:

The "easy" solution is to replace the original callback function with a `noop` function whenever we set `finished` to true, so we don't add too much complexity to `waitFor` internals.

Another solution would be to add an "early return" to `checkCallback`,  `onDone`, `handleTimeout` whenever `finished` is `true`, like so:

```diff
function checkCallback() {
+ if (finished || promiseStatus === 'pending') return
- if ( || promiseStatus === 'pending') return
```
```diff
function onDone(error, result) {
+ if (finished) return
finished = true
```
```diff
function handleTimeout() {
+ if (finished) return
let error
```


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs): N/A
- [x] Tests
- [ ] TypeScript definitions updated: N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

resolves https://github.com/testing-library/dom-testing-library/issues/1270
